### PR TITLE
Add patch-cable connection model between node terminals

### DIFF
--- a/src/components/controls/rotary-control/RotaryControl.tsx
+++ b/src/components/controls/rotary-control/RotaryControl.tsx
@@ -7,7 +7,8 @@ import { Input } from "../../ui/input";
 const TRACK_START_ANGLE = 210;
 const TRACK_SWEEP_ANGLE = 300;
 
-// pixels of vertical drag needed to sweep the value from 0 to 1
+// pixels of vertical drag needed to sweep the value from 0 to 1 (continuous
+// mode) or from the first to the last stage (staged mode)
 const DRAG_PX_PER_FULL_SWEEP = 100;
 
 export type RotaryControlSize = "sm" | "md";
@@ -17,7 +18,16 @@ const SIZE_PX: Record<RotaryControlSize, number> = {
   md: 40,
 };
 
-interface RotaryControlProps {
+export interface RotaryControlStage {
+  // passed straight to onChange/stored internally - e.g. a Tone.js Time
+  // notation string like "8n"
+  value: string;
+  // shown in the value readout when this stage is selected - e.g. "1/8"
+  label: string;
+}
+
+interface RotaryControlContinuousProps {
+  mode?: "continuous";
   size?: RotaryControlSize;
   // optionally-controlled: pass both to drive the value externally (e.g.
   // from Amp's envelope state); omit both to let RotaryControl own its
@@ -25,6 +35,17 @@ interface RotaryControlProps {
   value?: number;
   onChange?: (value: number) => void;
 }
+
+interface RotaryControlStagedProps {
+  mode: "staged";
+  size?: RotaryControlSize;
+  // discrete positions the knob can snap to, in order around the track
+  stages: RotaryControlStage[];
+  value?: string;
+  onChange?: (value: string) => void;
+}
+
+type RotaryControlProps = RotaryControlContinuousProps | RotaryControlStagedProps;
 
 function polarToCartesian(
   centerX: number,
@@ -71,30 +92,76 @@ function valueToAngle(value: number) {
   return TRACK_START_ANGLE + value * TRACK_SWEEP_ANGLE;
 }
 
-export default function RotaryControl({
-  size = "sm",
-  value: controlledValue,
-  onChange,
-}: RotaryControlProps) {
+// evenly spaces `count` stages across the track, first at TRACK_START_ANGLE,
+// last at TRACK_START_ANGLE + TRACK_SWEEP_ANGLE
+function stageAngle(index: number, count: number) {
+  if (count <= 1) return TRACK_START_ANGLE;
+  return TRACK_START_ANGLE + (index / (count - 1)) * TRACK_SWEEP_ANGLE;
+}
+
+export default function RotaryControl(props: RotaryControlProps) {
+  const { size = "sm" } = props;
+  const isStaged = props.mode === "staged";
+  const stages = isStaged ? props.stages : undefined;
+
   const rotaryControl = useRef<SVGSVGElement | null>(null);
 
   const ddRef = useRef<DragAndDrop | null>(null);
 
   const lastYRef = useRef<number | null>(null);
 
+  // continuous 0-1 drag position, shared by both modes: it *is* the value
+  // in continuous mode, and gets quantized to a stage index in staged mode
+  const rawRef = useRef(0.5);
+
+  const lastStageIndexRef = useRef(0);
+
   const sizePx = SIZE_PX[size];
 
-  const [internalValue, setInternalValue] = useState(0.5);
+  const [internalContinuousValue, setInternalContinuousValue] = useState(0.5);
+  const [internalStagedValue, setInternalStagedValue] = useState<
+    string | undefined
+  >(undefined);
 
-  const value = controlledValue ?? internalValue;
+  const continuousValue = !isStaged
+    ? (props.value ?? internalContinuousValue)
+    : 0;
+
+  const stagedValue = isStaged
+    ? (props.value ?? internalStagedValue ?? stages![0]?.value)
+    : undefined;
+
+  const stageIndex =
+    isStaged && stages
+      ? Math.max(
+          0,
+          stages.findIndex((stage) => stage.value === stagedValue),
+        )
+      : 0;
 
   // read by the drag handler below, which is registered once on mount and
-  // otherwise wouldn't see updates to `value`/`onChange`
-  const valueRef = useRef(value);
-  valueRef.current = value;
+  // otherwise wouldn't see updates to props/state
+  const modeRef = useRef(props.mode ?? "continuous");
+  modeRef.current = props.mode ?? "continuous";
 
-  const onChangeRef = useRef(onChange);
-  onChangeRef.current = onChange;
+  const continuousValueRef = useRef(continuousValue);
+  continuousValueRef.current = continuousValue;
+
+  const stageIndexRef = useRef(stageIndex);
+  stageIndexRef.current = stageIndex;
+
+  const stagesRef = useRef(stages);
+  stagesRef.current = stages;
+
+  const onChangeContinuousRef = useRef<((value: number) => void) | undefined>(
+    undefined,
+  );
+  onChangeContinuousRef.current = !isStaged ? props.onChange : undefined;
+
+  const onChangeStagedRef = useRef<((value: string) => void) | undefined>(
+    undefined,
+  );
+  onChangeStagedRef.current = isStaged ? props.onChange : undefined;
 
   useEffect(() => {
     const dd = new DragAndDrop().setHost(rotaryControl.current!);
@@ -104,6 +171,17 @@ export default function RotaryControl({
 
       if (type === "start") {
         lastYRef.current = clientY;
+
+        // seed the continuous drag position from wherever we currently
+        // are, so a staged drag starts at the current stage rather than
+        // jumping to wherever a stale rawRef last left off
+        const stagesNow = stagesRef.current;
+        rawRef.current =
+          modeRef.current === "staged" && stagesNow && stagesNow.length > 1
+            ? stageIndexRef.current / (stagesNow.length - 1)
+            : continuousValueRef.current;
+
+        lastStageIndexRef.current = stageIndexRef.current;
         return;
       }
 
@@ -114,13 +192,32 @@ export default function RotaryControl({
 
         const next = Math.min(
           1,
-          Math.max(0, valueRef.current + deltaY / DRAG_PX_PER_FULL_SWEEP),
+          Math.max(0, rawRef.current + deltaY / DRAG_PX_PER_FULL_SWEEP),
         );
+        rawRef.current = next;
 
-        if (onChangeRef.current) {
-          onChangeRef.current(next);
+        if (modeRef.current === "staged") {
+          const stagesNow = stagesRef.current;
+          if (!stagesNow || stagesNow.length === 0) return;
+
+          const nextIndex = Math.round(next * (stagesNow.length - 1));
+
+          if (nextIndex === lastStageIndexRef.current) return;
+          lastStageIndexRef.current = nextIndex;
+
+          const nextValue = stagesNow[nextIndex].value;
+
+          if (onChangeStagedRef.current) {
+            onChangeStagedRef.current(nextValue);
+          } else {
+            setInternalStagedValue(nextValue);
+          }
         } else {
-          setInternalValue(next);
+          if (onChangeContinuousRef.current) {
+            onChangeContinuousRef.current(next);
+          } else {
+            setInternalContinuousValue(next);
+          }
         }
       }
     });
@@ -132,13 +229,20 @@ export default function RotaryControl({
     };
   }, []);
 
-  const valueAngle = valueToAngle(value);
+  const valueAngle =
+    isStaged && stages
+      ? stageAngle(stageIndex, stages.length)
+      : valueToAngle(continuousValue);
+
+  const readoutText = isStaged
+    ? (stages?.[stageIndex]?.label ?? "")
+    : (continuousValue * 100).toFixed(0);
 
   return (
     <div style={{ width: sizePx + 17 }}>
       <div className="flex flex-col mb-2">
         <div className="flex text-sm justify-center align-center">
-          <Input className="p-2 h-6" value={(value * 100).toFixed(0)} />
+          <Input className="p-2 h-6" value={readoutText} />
         </div>
       </div>
 
@@ -176,6 +280,37 @@ export default function RotaryControl({
               valueAngle,
             )}
           />
+
+          {isStaged &&
+            stages?.map((stage, i) => {
+              const angle = stageAngle(i, stages.length);
+              const inner = polarToCartesian(
+                sizePx / 2,
+                sizePx / 2,
+                sizePx / 2 - 2,
+                angle,
+              );
+              const outer = polarToCartesian(
+                sizePx / 2,
+                sizePx / 2,
+                sizePx / 2 + 4,
+                angle,
+              );
+              const active = i === stageIndex;
+
+              return (
+                <line
+                  key={stage.value}
+                  x1={inner.x}
+                  y1={inner.y}
+                  x2={outer.x}
+                  y2={outer.y}
+                  strokeWidth={active ? 2 : 1}
+                  className={active ? "stroke-stone-800" : "stroke-stone-400"}
+                />
+              );
+            })}
+
           <g
             className="grabbable rotating-component"
             style={{ transform: `rotate(${valueAngle - 180}deg)` }}

--- a/src/components/editor/workspace/Workspace.tsx
+++ b/src/components/editor/workspace/Workspace.tsx
@@ -25,6 +25,7 @@ export function Workspace() {
 
   useEffect(() => {
     patientLoad.setSource("camera", transformRef.current);
+    patientLoad.setSource("viewportHost", hostRef.current);
   }, []);
 
   useEffect(() => {

--- a/src/components/editor/world/Connections.tsx
+++ b/src/components/editor/world/Connections.tsx
@@ -1,0 +1,42 @@
+import { ENV } from "@/env";
+import { useConnections } from "@/context/connections/ConnectionsContext";
+import { describeConnectionPath } from "@/utils/workspace/connection-path";
+
+/**
+ * SVG overlay drawing every committed connection plus the in-progress
+ * drag-to-connect attempt, if any. Lives inside `World` so it shares its
+ * content-space coordinate system and moves with pan/zoom for free.
+ */
+export function Connections() {
+  const { connections, attempt } = useConnections();
+
+  return (
+    <svg
+      width={ENV.worldDims + "px"}
+      height={ENV.worldDims + "px"}
+      className="absolute inset-0 pointer-events-none"
+    >
+      {connections.map((connection) => (
+        <path
+          key={connection.id}
+          d={describeConnectionPath(connection.from, connection.to)}
+          stroke="rgb(87 83 78 / 0.6)"
+          strokeWidth={2}
+          strokeLinecap="round"
+          fill="none"
+        />
+      ))}
+
+      {attempt && (
+        <path
+          d={describeConnectionPath(attempt.from, attempt.to)}
+          stroke="rgb(87 83 78 / 0.35)"
+          strokeWidth={2}
+          strokeDasharray="4 3"
+          strokeLinecap="round"
+          fill="none"
+        />
+      )}
+    </svg>
+  );
+}

--- a/src/components/editor/world/World.tsx
+++ b/src/components/editor/world/World.tsx
@@ -2,6 +2,8 @@ import { ENV } from "@/env";
 import "./World.css";
 import { NodeWrapper } from "@/components/nodes/node-wrapper/NodeWrapper";
 import { NodeMap } from "@/utils/node-map";
+import { ConnectionsProvider } from "@/context/connections/ConnectionsContext";
+import { Connections } from "./Connections";
 
 interface WorldNode {
   id: string;
@@ -27,21 +29,24 @@ export function World() {
         width: ENV.worldDims + "px",
       }}
     >
-      {INITIAL_NODES.map(({ id, type, position }) => {
-        const NodeComponent = NodeMap[type];
+      <ConnectionsProvider>
+        {INITIAL_NODES.map(({ id, type, position }) => {
+          const NodeComponent = NodeMap[type];
 
-        return (
-          <span
-            key={id}
-            className="absolute"
-            style={{ left: position.left + "px", top: position.top + "px" }}
-          >
-            <NodeWrapper>
-              <NodeComponent />
-            </NodeWrapper>
-          </span>
-        );
-      })}
+          return (
+            <span
+              key={id}
+              className="absolute"
+              style={{ left: position.left + "px", top: position.top + "px" }}
+            >
+              <NodeWrapper id={id}>
+                <NodeComponent />
+              </NodeWrapper>
+            </span>
+          );
+        })}
+        <Connections />
+      </ConnectionsProvider>
       <Background />
     </div>
   );

--- a/src/components/editor/world/World.tsx
+++ b/src/components/editor/world/World.tsx
@@ -18,6 +18,7 @@ const INITIAL_NODES: WorldNode[] = [
   { id: "keyboard-1", type: "keyboard", position: { left: 800, top: 400 } },
   { id: "midiBox-1", type: "midiBox", position: { left: 550, top: 150 } },
   { id: "filter-1", type: "filter", position: { left: 300, top: 650 } },
+  { id: "delay-1", type: "delay", position: { left: 900, top: 750 } },
 ];
 
 export function World() {

--- a/src/components/effects/delay/Delay.tsx
+++ b/src/components/effects/delay/Delay.tsx
@@ -1,18 +1,35 @@
 import { useState } from "react";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { ControlContainer } from "@/components/instruments/polysynth/ControlContainer";
-import RotaryControl from "@/components/controls/rotary-control/RotaryControl";
+import RotaryControl, {
+  type RotaryControlStage,
+} from "@/components/controls/rotary-control/RotaryControl";
 import type { DelayValue } from "./types";
+
+// straight note subdivisions - dotted/triplet variants aren't offered yet
+const TIME_STAGES: RotaryControlStage[] = [
+  { value: "1n", label: "1/1" },
+  { value: "2n", label: "1/2" },
+  { value: "4n", label: "1/4" },
+  { value: "8n", label: "1/8" },
+  { value: "16n", label: "1/16" },
+  { value: "32n", label: "1/32" },
+];
 
 export function Delay() {
   const [delayValues, setDelayValues] = useState<DelayValue>({
-    time: 0.5,
+    time: "8n",
     feedback: 0.5,
     wet: 0.5,
   });
 
-  const setValue = (key: keyof DelayValue) => (value: number) =>
-    setDelayValues((state) => ({ ...state, [key]: value }));
+  const setTime = (time: string) =>
+    setDelayValues((state) => ({ ...state, time }));
+
+  const setFeedback = (feedback: number) =>
+    setDelayValues((state) => ({ ...state, feedback }));
+
+  const setWet = (wet: number) => setDelayValues((state) => ({ ...state, wet }));
 
   return (
     <Card className="delay py-3 px-0 w-[220px]">
@@ -22,18 +39,17 @@ export function Delay() {
       <CardContent className="px-3 flex gap-2 justify-center">
         <ControlContainer label="Time">
           <RotaryControl
+            mode="staged"
+            stages={TIME_STAGES}
             value={delayValues.time}
-            onChange={setValue("time")}
+            onChange={setTime}
           />
         </ControlContainer>
         <ControlContainer label="Feedback">
-          <RotaryControl
-            value={delayValues.feedback}
-            onChange={setValue("feedback")}
-          />
+          <RotaryControl value={delayValues.feedback} onChange={setFeedback} />
         </ControlContainer>
         <ControlContainer label="Wet">
-          <RotaryControl value={delayValues.wet} onChange={setValue("wet")} />
+          <RotaryControl value={delayValues.wet} onChange={setWet} />
         </ControlContainer>
       </CardContent>
     </Card>

--- a/src/components/effects/delay/Delay.tsx
+++ b/src/components/effects/delay/Delay.tsx
@@ -1,0 +1,43 @@
+import { useState } from "react";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { ControlContainer } from "@/components/instruments/polysynth/ControlContainer";
+import RotaryControl from "@/components/controls/rotary-control/RotaryControl";
+import type { DelayValue } from "./types";
+
+export function Delay() {
+  const [delayValues, setDelayValues] = useState<DelayValue>({
+    time: 0.5,
+    feedback: 0.5,
+    wet: 0.5,
+  });
+
+  const setValue = (key: keyof DelayValue) => (value: number) =>
+    setDelayValues((state) => ({ ...state, [key]: value }));
+
+  return (
+    <Card className="delay py-3 px-0 w-[220px]">
+      <CardHeader>
+        <span className="pix-font color-stone-500 text-4xl">Delay</span>
+      </CardHeader>
+      <CardContent className="px-3 flex gap-2 justify-center">
+        <ControlContainer label="Time">
+          <RotaryControl
+            value={delayValues.time}
+            onChange={setValue("time")}
+          />
+        </ControlContainer>
+        <ControlContainer label="Feedback">
+          <RotaryControl
+            value={delayValues.feedback}
+            onChange={setValue("feedback")}
+          />
+        </ControlContainer>
+        <ControlContainer label="Wet">
+          <RotaryControl value={delayValues.wet} onChange={setValue("wet")} />
+        </ControlContainer>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default Delay;

--- a/src/components/effects/delay/types.ts
+++ b/src/components/effects/delay/types.ts
@@ -1,7 +1,9 @@
-// all three are 0-1 knob values; real time/feedback/wet ranges are derived
-// from these once the Tone.js delay is actually wired up
+// feedback/wet are 0-1 knob values; real ranges are derived from these once
+// the Tone.js delay is actually wired up. time is a Tone.js Time notation
+// string (e.g. "8n") rather than a 0-1 value, chosen from a fixed set of
+// note-subdivision stages rather than continuously.
 export interface DelayValue {
-  time: number;
+  time: string;
   feedback: number;
   wet: number;
 }

--- a/src/components/effects/delay/types.ts
+++ b/src/components/effects/delay/types.ts
@@ -1,0 +1,7 @@
+// all three are 0-1 knob values; real time/feedback/wet ranges are derived
+// from these once the Tone.js delay is actually wired up
+export interface DelayValue {
+  time: number;
+  feedback: number;
+  wet: number;
+}

--- a/src/components/nodes/node-wrapper/NodeWrapper.tsx
+++ b/src/components/nodes/node-wrapper/NodeWrapper.tsx
@@ -5,37 +5,45 @@ import { Button } from "@/components/ui/button";
 import { HiOutlineVolumeOff } from "react-icons/hi";
 import { Input } from "@/components/ui/input";
 import type { ReactNode } from "react";
+import { Terminal } from "./Terminal";
 
 interface NodeWrapperProps {
+  id: string;
   children: ReactNode;
 }
 
-export function NodeWrapper({ children }: NodeWrapperProps) {
+export function NodeWrapper({ id, children }: NodeWrapperProps) {
   return (
-    <div className="node-wrapper inline-flex flex-col">
-      <div className="title-container h-12 w-full flex">
-        <div className="grow flex items-center">
-          <Input value="Keyboard 1" />
+    <div className="inline-flex items-center gap-1">
+      <Terminal nodeId={id} side="input" />
+
+      <div className="node-wrapper inline-flex flex-col">
+        <div className="title-container h-12 w-full flex">
+          <div className="grow flex items-center">
+            <Input value="Keyboard 1" />
+          </div>
+          <span className="flex gap-[2px]">
+            <div className="flex items-center justify-center">
+              <Button variant="outline" size="icon">
+                <HiOutlineVolumeOff />
+              </Button>
+            </div>
+            <div className="flex items-center justify-center">
+              <Button variant="outline" size="icon">
+                <HiAdjustments />
+              </Button>
+            </div>
+            <div className="flex items-center justify-center">
+              <Button variant="outline" size="icon">
+                <HiOutlineX />
+              </Button>
+            </div>
+          </span>
         </div>
-        <span className="flex gap-[2px]">
-          <div className="flex items-center justify-center">
-            <Button variant="outline" size="icon">
-              <HiOutlineVolumeOff />
-            </Button>
-          </div>
-          <div className="flex items-center justify-center">
-            <Button variant="outline" size="icon">
-              <HiAdjustments />
-            </Button>
-          </div>
-          <div className="flex items-center justify-center">
-            <Button variant="outline" size="icon">
-              <HiOutlineX />
-            </Button>
-          </div>
-        </span>
+        <div className="node-container">{children}</div>
       </div>
-      <div className="node-container">{children}</div>
+
+      <Terminal nodeId={id} side="output" />
     </div>
   );
 }

--- a/src/components/nodes/node-wrapper/Terminal.tsx
+++ b/src/components/nodes/node-wrapper/Terminal.tsx
@@ -1,0 +1,97 @@
+import { useEffect, useRef } from "react";
+import { DragAndDrop } from "@/utils/drag-and-drop";
+import { useConnections } from "@/context/connections/ConnectionsContext";
+
+export type TerminalSide = "input" | "output";
+
+interface TerminalProps {
+  nodeId: string;
+  side: TerminalSide;
+}
+
+/**
+ * A node's connection point: `input` (left) terminals are just a drop
+ * target, `output` (right) terminals also start a drag-to-connect gesture.
+ * Signal is meant to flow left-to-right, matching tonix-2-react's reference
+ * layout this was ported from.
+ */
+export function Terminal({ nodeId, side }: TerminalProps) {
+  const elRef = useRef<HTMLDivElement | null>(null);
+
+  const { terminalContentPoint, clientContentPoint, beginAttempt, updateAttempt, commitAttempt, cancelAttempt } =
+    useConnections();
+
+  useEffect(() => {
+    if (side !== "output") {
+      return;
+    }
+
+    const el = elRef.current!;
+    const dd = new DragAndDrop().setHost(el);
+
+    dd.listen(({ type, e }) => {
+      if (type === "start") {
+        const from = terminalContentPoint(el);
+
+        if (from) {
+          beginAttempt(nodeId, from);
+        }
+
+        return;
+      }
+
+      if (type === "dragging") {
+        const to = clientContentPoint(e.clientX, e.clientY);
+
+        if (to) {
+          updateAttempt(to);
+        }
+
+        return;
+      }
+
+      // "done": commit only if released over a different node's input terminal
+      const target = document
+        .elementFromPoint(e.clientX, e.clientY)
+        ?.closest<HTMLElement>('[data-terminal-side="input"]');
+
+      const targetNodeId = target?.dataset.nodeId;
+
+      if (target && targetNodeId && targetNodeId !== nodeId) {
+        const to = terminalContentPoint(target);
+
+        if (to) {
+          commitAttempt(to);
+          return;
+        }
+      }
+
+      cancelAttempt();
+    });
+
+    return () => dd.done();
+  }, [
+    side,
+    nodeId,
+    terminalContentPoint,
+    clientContentPoint,
+    beginAttempt,
+    updateAttempt,
+    commitAttempt,
+    cancelAttempt,
+  ]);
+
+  return (
+    <div
+      ref={elRef}
+      data-node-id={nodeId}
+      data-terminal-side={side}
+      className={
+        "w-3 h-3 rounded-full border-2 border-white shadow-sm shrink-0 " +
+        (side === "output"
+          ? "bg-stone-500 cursor-crosshair"
+          : "bg-stone-300")
+      }
+    />
+  );
+}

--- a/src/context/connections/ConnectionsContext.tsx
+++ b/src/context/connections/ConnectionsContext.tsx
@@ -1,0 +1,160 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import type { ReactZoomPanPinchContentRef } from "react-zoom-pan-pinch";
+import { patientLoad } from "@/utils/workspace/patient-load";
+import {
+  clientPointToContent,
+  elementCenterToContent,
+} from "@/utils/workspace/viewport";
+import type { Point } from "@/utils/workspace/connection-path";
+
+export interface Connection {
+  id: string;
+  from: Point;
+  to: Point;
+}
+
+interface Attempt {
+  nodeId: string;
+  from: Point;
+  to: Point;
+}
+
+interface ConnectionsContextValue {
+  connections: Connection[];
+  attempt: Attempt | null;
+  /** Content-space point for a terminal element's current center. */
+  terminalContentPoint: (el: HTMLElement) => Point | null;
+  /** Content-space point for a raw mouse event's client coordinates. */
+  clientContentPoint: (clientX: number, clientY: number) => Point | null;
+  beginAttempt: (nodeId: string, from: Point) => void;
+  updateAttempt: (to: Point) => void;
+  /** Commits the in-progress attempt as a connection ending at `to`, then clears it. */
+  commitAttempt: (to: Point) => void;
+  /** Discards the in-progress attempt without creating a connection. */
+  cancelAttempt: () => void;
+}
+
+const ConnectionsContext = createContext<ConnectionsContextValue | null>(
+  null,
+);
+
+let nextConnectionId = 0;
+
+export function ConnectionsProvider({ children }: { children: ReactNode }) {
+  const [connections, setConnections] = useState<Connection[]>([]);
+  const [attempt, setAttempt] = useState<Attempt | null>(null);
+
+  // fetched once via patientLoad, then read synchronously on every drag
+  // event rather than re-subscribing per read
+  const hostRef = useRef<HTMLElement | null>(null);
+  const cameraRef = useRef<ReactZoomPanPinchContentRef | null>(null);
+
+  useEffect(() => {
+    patientLoad.getSource<HTMLElement>("viewportHost", (host) => {
+      hostRef.current = host;
+    });
+    patientLoad.getSource<ReactZoomPanPinchContentRef>("camera", (camera) => {
+      cameraRef.current = camera;
+    });
+  }, []);
+
+  const withHostAndScale = useCallback(
+    <T,>(fn: (host: HTMLElement, state: ReactZoomPanPinchContentRef["instance"]["transformState"]) => T): T | null => {
+      const host = hostRef.current;
+      const camera = cameraRef.current;
+
+      if (!host || !camera) {
+        return null;
+      }
+
+      return fn(host, camera.instance.transformState);
+    },
+    [],
+  );
+
+  const terminalContentPoint = useCallback(
+    (el: HTMLElement) =>
+      withHostAndScale((host, state) => elementCenterToContent(el, host, state)),
+    [withHostAndScale],
+  );
+
+  const clientContentPoint = useCallback(
+    (clientX: number, clientY: number) =>
+      withHostAndScale((host, state) =>
+        clientPointToContent(clientX, clientY, host, state),
+      ),
+    [withHostAndScale],
+  );
+
+  const beginAttempt = useCallback((nodeId: string, from: Point) => {
+    setAttempt({ nodeId, from, to: from });
+  }, []);
+
+  const updateAttempt = useCallback((to: Point) => {
+    setAttempt((current) => (current ? { ...current, to } : current));
+  }, []);
+
+  const commitAttempt = useCallback((to: Point) => {
+    setAttempt((current) => {
+      if (current) {
+        setConnections((conns) => [
+          ...conns,
+          { id: `connection-${nextConnectionId++}`, from: current.from, to },
+        ]);
+      }
+      return null;
+    });
+  }, []);
+
+  const cancelAttempt = useCallback(() => {
+    setAttempt(null);
+  }, []);
+
+  const value = useMemo<ConnectionsContextValue>(
+    () => ({
+      connections,
+      attempt,
+      terminalContentPoint,
+      clientContentPoint,
+      beginAttempt,
+      updateAttempt,
+      commitAttempt,
+      cancelAttempt,
+    }),
+    [
+      connections,
+      attempt,
+      terminalContentPoint,
+      clientContentPoint,
+      beginAttempt,
+      updateAttempt,
+      commitAttempt,
+      cancelAttempt,
+    ],
+  );
+
+  return (
+    <ConnectionsContext.Provider value={value}>
+      {children}
+    </ConnectionsContext.Provider>
+  );
+}
+
+export function useConnections(): ConnectionsContextValue {
+  const ctx = useContext(ConnectionsContext);
+
+  if (!ctx) {
+    throw new Error("useConnections must be used within a ConnectionsProvider");
+  }
+
+  return ctx;
+}

--- a/src/stories/delay.stories.tsx
+++ b/src/stories/delay.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Delay } from "@/components/effects/delay/Delay";
+
+const meta = {
+  component: Delay,
+  title: "Delay",
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "A delay effect node: Time/Feedback/Wet knobs, following the " +
+          "same `ControlContainer` + `RotaryControl` pattern used by " +
+          "`Oscillator`'s knob row. Ported from `tonix-2-react`'s " +
+          "`effects/ping-pong-delay` shell, rebuilt from scratch rather " +
+          "than copied — the original's knobs were hardcoded to 0 and " +
+          "never wired to its own state. This is a visual/state shell " +
+          "only; no audio engine is wired up yet.",
+      },
+    },
+  },
+} satisfies Meta<typeof Delay>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/stories/node-wrapper.stories.tsx
+++ b/src/stories/node-wrapper.stories.tsx
@@ -1,11 +1,23 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { NodeWrapper } from "@/components/nodes/node-wrapper/NodeWrapper";
 import { Polysynth } from "@/components/instruments/polysynth/Polysynth";
+import { ConnectionsProvider } from "@/context/connections/ConnectionsContext";
 
 const meta = {
   component: NodeWrapper,
   title: "NodeWrapper",
   tags: ["autodocs"],
+  // NodeWrapper's terminals read from ConnectionsContext (normally provided
+  // by World.tsx); outside that, dragging a terminal here is inert rather
+  // than functional, since no viewport/camera is registered to convert
+  // drag coordinates into content-space.
+  decorators: [
+    (Story) => (
+      <ConnectionsProvider>
+        <Story />
+      </ConnectionsProvider>
+    ),
+  ],
   parameters: {
     layout: "centered",
     docs: {
@@ -26,6 +38,7 @@ type Story = StoryObj<typeof meta>;
 
 export const WrappingPolysynth: Story = {
   args: {
+    id: "polysynth-story",
     children: <Polysynth />,
   },
 };

--- a/src/stories/rotary-control.stories.tsx
+++ b/src/stories/rotary-control.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import RotaryControl from "@/components/controls/rotary-control/RotaryControl";
+import RotaryControl, {
+  type RotaryControlStage,
+} from "@/components/controls/rotary-control/RotaryControl";
 
 const meta = {
   component: RotaryControl,
@@ -9,11 +11,14 @@ const meta = {
     docs: {
       description: {
         component:
-          "A draggable rotary knob representing a value between 0 and 1. " +
-          "Click and drag vertically anywhere on the page to change the " +
-          "value — dragging up increases it, dragging down decreases it, " +
-          "and it clamps at both ends. Used throughout `Polysynth`'s " +
-          "oscillator controls (phase, gain, pan).",
+          "A draggable rotary knob, in two modes. `continuous` (the " +
+          "default) represents a free value between 0 and 1 — used " +
+          "throughout `Polysynth`'s oscillator controls (phase, gain, " +
+          "pan). `staged` instead snaps to a fixed list of labeled " +
+          "stages, e.g. tempo-synced note subdivisions for `Delay`'s " +
+          "Time knob. In both modes, click and drag vertically anywhere " +
+          "on the page to change the value — dragging up increases it, " +
+          "dragging down decreases it, and it clamps at both ends.",
       },
     },
   },
@@ -27,6 +32,16 @@ const meta = {
         "knob needs to be more prominent or easier to grab.",
       table: {
         defaultValue: { summary: "sm" },
+      },
+    },
+    mode: {
+      control: "radio",
+      options: ["continuous", "staged"],
+      description:
+        "`continuous` for a free 0-1 value (default); `staged` to snap " +
+        "to a fixed `stages` list instead.",
+      table: {
+        defaultValue: { summary: "continuous" },
       },
     },
   },
@@ -52,6 +67,36 @@ export const Medium: Story = {
     docs: {
       description: {
         story: "A larger variant for standalone or more prominent placements.",
+      },
+    },
+  },
+};
+
+const timeStages: RotaryControlStage[] = [
+  { value: "1n", label: "1/1" },
+  { value: "2n", label: "1/2" },
+  { value: "4n", label: "1/4" },
+  { value: "8n", label: "1/8" },
+  { value: "16n", label: "1/16" },
+  { value: "32n", label: "1/32" },
+];
+
+export const Staged: Story = {
+  args: {
+    mode: "staged",
+    stages: timeStages,
+    value: "8n",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The same six note-subdivision stages `Delay`'s Time knob " +
+          "uses. A small tick marks each stage's position on the track " +
+          "(the current one bolded), and the readout shows its label " +
+          "instead of a percentage. Drag still works the same way, but " +
+          "the value quantizes to the nearest stage as you go rather " +
+          "than moving freely.",
       },
     },
   },

--- a/src/utils/node-map.tsx
+++ b/src/utils/node-map.tsx
@@ -3,6 +3,7 @@ import Keyboard from "../components/nodes/keyboard/Keyboard";
 import { Polysynth } from "../components/instruments/polysynth/Polysynth";
 import { MidiBox } from "../components/nodes/midi-box/MidiBox";
 import { Filter } from "../components/effects/filter/Filter";
+import { Delay } from "../components/effects/delay/Delay";
 
 export type INodeMap = Record<string, ComponentType>;
 
@@ -11,4 +12,5 @@ export const NodeMap: INodeMap = {
   polysynth: Polysynth,
   midiBox: MidiBox,
   filter: Filter,
+  delay: Delay,
 };

--- a/src/utils/workspace/connection-path.ts
+++ b/src/utils/workspace/connection-path.ts
@@ -1,0 +1,24 @@
+export interface Point {
+  x: number;
+  y: number;
+}
+
+/**
+ * SVG path `d` for a patch cable between two content-space points: a pair of
+ * quadratic curves that bow through the horizontal midpoint between them.
+ * Ported from tonix-2-react's Connections component (`prepare()`).
+ */
+export function describeConnectionPath(from: Point, to: Point): string {
+  const bb = {
+    height: from.y - to.y,
+    width: from.x - to.x,
+  };
+
+  return [
+    `M${from.x},${from.y} `,
+    `Q${to.x + bb.width / 2},${from.y} `,
+    `${to.x + bb.width / 2},${to.y + bb.height / 2} `,
+    `Q${to.x + bb.width / 2},${from.y - bb.height} `,
+    `${to.x},${to.y}`,
+  ].join("");
+}

--- a/src/utils/workspace/viewport.ts
+++ b/src/utils/workspace/viewport.ts
@@ -30,3 +30,39 @@ export function viewportToContent(
     y: (viewportY - positionY) / scale,
   };
 }
+
+/**
+ * Convert a raw client (`event.clientX/clientY`) point to content-space.
+ * `host` is the untransformed element the pan/zoom wrapper is mounted in
+ * (its bounding rect is viewport-space's own origin), so subtracting its
+ * rect turns a page coordinate into a viewport-space one `viewportToContent`
+ * can consume.
+ */
+export function clientPointToContent(
+  clientX: number,
+  clientY: number,
+  host: HTMLElement,
+  state: { scale: number; positionX: number; positionY: number }
+) {
+  const hostRect = host.getBoundingClientRect();
+  return viewportToContent(clientX - hostRect.left, clientY - hostRect.top, state);
+}
+
+/**
+ * Convert the center of a rendered element to content-space, via the same
+ * `host` + `state` as `clientPointToContent`. Useful for anchoring a visual
+ * (e.g. a connection endpoint) to wherever a DOM element currently is.
+ */
+export function elementCenterToContent(
+  el: HTMLElement,
+  host: HTMLElement,
+  state: { scale: number; positionX: number; positionY: number }
+) {
+  const rect = el.getBoundingClientRect();
+  return clientPointToContent(
+    rect.left + rect.width / 2,
+    rect.top + rect.height / 2,
+    host,
+    state
+  );
+}


### PR DESCRIPTION
## Summary

Closes #26 (migration reference: `harrycarron/tonix-2-react`). Every `NodeWrapper` now has an input (left) and output (right) terminal:

- Dragging from an output terminal draws a live bezier preview cable following the cursor.
- Dropping it on a **different** node's input terminal commits a connection, rendered as an SVG overlay inside `World`.
- Dropping anywhere else (empty canvas, or the same node's own input) cancels the attempt — no connection created.

## Implementation notes

- Bezier path math ported from `tonix-2-react`'s `Connections.prepare()`, stripped of its Redux coupling (`src/utils/workspace/connection-path.ts`).
- Connection/attempt state lives in a new `ConnectionsContext`, scoped to `World` — deliberately **not** resolving the open state-management question from CLAUDE.md, since this is the first real cross-node state and a local context was sufficient without pre-committing to a global approach.
- Coordinate conversion reuses/extends `utils/workspace/viewport.ts` (`clientPointToContent`, `elementCenterToContent`) instead of duplicating scale/position math, per CLAUDE.md's coordinate-model guidance. This is also the first real consumer of the existing `"camera"` `patientLoad` registration (added a matching `"viewportHost"` source alongside it in `Workspace.tsx`).
- Scope, per issue #26: UI/interaction model only — no audio routing (tracked separately).

## Test plan

- [x] `npm run build` passes clean
- [x] `npm run lint` passes clean (one new warning, same shape as an existing pre-accepted one: `ConnectionsContext.tsx` exports both a Provider and a hook from one file, same pattern as `button.tsx`)
- [x] `npm run build-storybook` passes clean (updated the `NodeWrapper` story for the new required `id` prop + wrapped it in `ConnectionsProvider`)
- [x] Smoke-tested in a real browser via Playwright:
  - Drag from one node's output terminal to a different node's input terminal → connection committed, dashed preview replaced by solid cable
  - Drag to empty canvas space → attempt cancelled, no stray connection or lingering preview
  - Drag from a node's output back to its own input → rejected, no self-loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)