### PR TITLE
Add Delay effect node with staged rotary Time control

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,10 @@ npm run build-storybook    # static Storybook build
 ```
 There is no test runner wired up yet.
 
+## Code style
+
+Default to no comments. Only add one when it captures something critical that isn't obvious from the code itself — a non-obvious invariant, a workaround for a specific bug, a hidden constraint, or a gotcha that would otherwise cause a regression. Never write comments that just restate what the code does; well-named identifiers already cover that.
+
 ## Architecture (root project)
 
 The app is a node-based editor for building synth/audio patches on a large pannable/zoomable canvas ("world").

--- a/src/components/controls/rotary-control/RotaryControl.css
+++ b/src/components/controls/rotary-control/RotaryControl.css
@@ -1,6 +1,11 @@
 .rotating-component {
   transform-box: fill-box;
   transform-origin: center;
+  transition: transform 120ms ease-out;
+}
+
+.value-arc {
+  transition: stroke-dashoffset 120ms ease-out;
 }
 
 .knob-input-container {

--- a/src/components/controls/rotary-control/RotaryControl.tsx
+++ b/src/components/controls/rotary-control/RotaryControl.tsx
@@ -7,7 +7,8 @@ import { Input } from "../../ui/input";
 const TRACK_START_ANGLE = 210;
 const TRACK_SWEEP_ANGLE = 300;
 
-// pixels of vertical drag needed to sweep the value from 0 to 1
+// pixels of vertical drag needed to sweep the value from 0 to 1 (continuous
+// mode) or from the first to the last stage (staged mode)
 const DRAG_PX_PER_FULL_SWEEP = 100;
 
 export type RotaryControlSize = "sm" | "md";
@@ -17,7 +18,16 @@ const SIZE_PX: Record<RotaryControlSize, number> = {
   md: 40,
 };
 
-interface RotaryControlProps {
+export interface RotaryControlStage {
+  // passed straight to onChange/stored internally - e.g. a Tone.js Time
+  // notation string like "8n"
+  value: string;
+  // shown in the value readout when this stage is selected - e.g. "1/8"
+  label: string;
+}
+
+interface RotaryControlContinuousProps {
+  mode?: "continuous";
   size?: RotaryControlSize;
   // optionally-controlled: pass both to drive the value externally (e.g.
   // from Amp's envelope state); omit both to let RotaryControl own its
@@ -25,6 +35,17 @@ interface RotaryControlProps {
   value?: number;
   onChange?: (value: number) => void;
 }
+
+interface RotaryControlStagedProps {
+  mode: "staged";
+  size?: RotaryControlSize;
+  // discrete positions the knob can snap to, in order around the track
+  stages: RotaryControlStage[];
+  value?: string;
+  onChange?: (value: string) => void;
+}
+
+type RotaryControlProps = RotaryControlContinuousProps | RotaryControlStagedProps;
 
 function polarToCartesian(
   centerX: number,
@@ -71,30 +92,76 @@ function valueToAngle(value: number) {
   return TRACK_START_ANGLE + value * TRACK_SWEEP_ANGLE;
 }
 
-export default function RotaryControl({
-  size = "sm",
-  value: controlledValue,
-  onChange,
-}: RotaryControlProps) {
+// evenly spaces `count` stages across the track, first at TRACK_START_ANGLE,
+// last at TRACK_START_ANGLE + TRACK_SWEEP_ANGLE
+function stageAngle(index: number, count: number) {
+  if (count <= 1) return TRACK_START_ANGLE;
+  return TRACK_START_ANGLE + (index / (count - 1)) * TRACK_SWEEP_ANGLE;
+}
+
+export default function RotaryControl(props: RotaryControlProps) {
+  const { size = "sm" } = props;
+  const isStaged = props.mode === "staged";
+  const stages = isStaged ? props.stages : undefined;
+
   const rotaryControl = useRef<SVGSVGElement | null>(null);
 
   const ddRef = useRef<DragAndDrop | null>(null);
 
   const lastYRef = useRef<number | null>(null);
 
+  // continuous 0-1 drag position, shared by both modes: it *is* the value
+  // in continuous mode, and gets quantized to a stage index in staged mode
+  const rawRef = useRef(0.5);
+
+  const lastStageIndexRef = useRef(0);
+
   const sizePx = SIZE_PX[size];
 
-  const [internalValue, setInternalValue] = useState(0.5);
+  const [internalContinuousValue, setInternalContinuousValue] = useState(0.5);
+  const [internalStagedValue, setInternalStagedValue] = useState<
+    string | undefined
+  >(undefined);
 
-  const value = controlledValue ?? internalValue;
+  const continuousValue = !isStaged
+    ? (props.value ?? internalContinuousValue)
+    : 0;
+
+  const stagedValue = isStaged
+    ? (props.value ?? internalStagedValue ?? stages![0]?.value)
+    : undefined;
+
+  const stageIndex =
+    isStaged && stages
+      ? Math.max(
+          0,
+          stages.findIndex((stage) => stage.value === stagedValue),
+        )
+      : 0;
 
   // read by the drag handler below, which is registered once on mount and
-  // otherwise wouldn't see updates to `value`/`onChange`
-  const valueRef = useRef(value);
-  valueRef.current = value;
+  // otherwise wouldn't see updates to props/state
+  const modeRef = useRef(props.mode ?? "continuous");
+  modeRef.current = props.mode ?? "continuous";
 
-  const onChangeRef = useRef(onChange);
-  onChangeRef.current = onChange;
+  const continuousValueRef = useRef(continuousValue);
+  continuousValueRef.current = continuousValue;
+
+  const stageIndexRef = useRef(stageIndex);
+  stageIndexRef.current = stageIndex;
+
+  const stagesRef = useRef(stages);
+  stagesRef.current = stages;
+
+  const onChangeContinuousRef = useRef<((value: number) => void) | undefined>(
+    undefined,
+  );
+  onChangeContinuousRef.current = !isStaged ? props.onChange : undefined;
+
+  const onChangeStagedRef = useRef<((value: string) => void) | undefined>(
+    undefined,
+  );
+  onChangeStagedRef.current = isStaged ? props.onChange : undefined;
 
   useEffect(() => {
     const dd = new DragAndDrop().setHost(rotaryControl.current!);
@@ -104,6 +171,17 @@ export default function RotaryControl({
 
       if (type === "start") {
         lastYRef.current = clientY;
+
+        // seed the continuous drag position from wherever we currently
+        // are, so a staged drag starts at the current stage rather than
+        // jumping to wherever a stale rawRef last left off
+        const stagesNow = stagesRef.current;
+        rawRef.current =
+          modeRef.current === "staged" && stagesNow && stagesNow.length > 1
+            ? stageIndexRef.current / (stagesNow.length - 1)
+            : continuousValueRef.current;
+
+        lastStageIndexRef.current = stageIndexRef.current;
         return;
       }
 
@@ -114,13 +192,32 @@ export default function RotaryControl({
 
         const next = Math.min(
           1,
-          Math.max(0, valueRef.current + deltaY / DRAG_PX_PER_FULL_SWEEP),
+          Math.max(0, rawRef.current + deltaY / DRAG_PX_PER_FULL_SWEEP),
         );
+        rawRef.current = next;
 
-        if (onChangeRef.current) {
-          onChangeRef.current(next);
+        if (modeRef.current === "staged") {
+          const stagesNow = stagesRef.current;
+          if (!stagesNow || stagesNow.length === 0) return;
+
+          const nextIndex = Math.round(next * (stagesNow.length - 1));
+
+          if (nextIndex === lastStageIndexRef.current) return;
+          lastStageIndexRef.current = nextIndex;
+
+          const nextValue = stagesNow[nextIndex].value;
+
+          if (onChangeStagedRef.current) {
+            onChangeStagedRef.current(nextValue);
+          } else {
+            setInternalStagedValue(nextValue);
+          }
         } else {
-          setInternalValue(next);
+          if (onChangeContinuousRef.current) {
+            onChangeContinuousRef.current(next);
+          } else {
+            setInternalContinuousValue(next);
+          }
         }
       }
     });
@@ -132,13 +229,20 @@ export default function RotaryControl({
     };
   }, []);
 
-  const valueAngle = valueToAngle(value);
+  const valueAngle =
+    isStaged && stages
+      ? stageAngle(stageIndex, stages.length)
+      : valueToAngle(continuousValue);
+
+  const readoutText = isStaged
+    ? (stages?.[stageIndex]?.label ?? "")
+    : (continuousValue * 100).toFixed(0);
 
   return (
     <div style={{ width: sizePx + 17 }}>
       <div className="flex flex-col mb-2">
         <div className="flex text-sm justify-center align-center">
-          <Input className="p-2 h-6" value={(value * 100).toFixed(0)} />
+          <Input className="p-2 h-6" value={readoutText} />
         </div>
       </div>
 
@@ -176,6 +280,37 @@ export default function RotaryControl({
               valueAngle,
             )}
           />
+
+          {isStaged &&
+            stages?.map((stage, i) => {
+              const angle = stageAngle(i, stages.length);
+              const inner = polarToCartesian(
+                sizePx / 2,
+                sizePx / 2,
+                sizePx / 2 - 2,
+                angle,
+              );
+              const outer = polarToCartesian(
+                sizePx / 2,
+                sizePx / 2,
+                sizePx / 2 + 4,
+                angle,
+              );
+              const active = i === stageIndex;
+
+              return (
+                <line
+                  key={stage.value}
+                  x1={inner.x}
+                  y1={inner.y}
+                  x2={outer.x}
+                  y2={outer.y}
+                  strokeWidth={active ? 2 : 1}
+                  className={active ? "stroke-stone-800" : "stroke-stone-400"}
+                />
+              );
+            })}
+
           <g
             className="grabbable rotating-component"
             style={{ transform: `rotate(${valueAngle - 180}deg)` }}

--- a/src/components/controls/rotary-control/RotaryControl.tsx
+++ b/src/components/controls/rotary-control/RotaryControl.tsx
@@ -40,7 +40,9 @@ interface RotaryControlStagedProps {
   onChange?: (value: string) => void;
 }
 
-type RotaryControlProps = RotaryControlContinuousProps | RotaryControlStagedProps;
+type RotaryControlProps =
+  | RotaryControlContinuousProps
+  | RotaryControlStagedProps;
 
 function polarToCartesian(
   centerX: number,
@@ -223,6 +225,8 @@ export default function RotaryControl(props: RotaryControlProps) {
       ? stageAngle(stageIndex, stages.length)
       : valueToAngle(continuousValue);
 
+  const progress = (valueAngle - TRACK_START_ANGLE) / TRACK_SWEEP_ANGLE;
+
   const readoutText = isStaged
     ? (stages?.[stageIndex]?.label ?? "")
     : (continuousValue * 100).toFixed(0);
@@ -242,41 +246,13 @@ export default function RotaryControl(props: RotaryControlProps) {
           width={sizePx}
           ref={rotaryControl}
         >
-          <path
-            fill="none"
-            strokeWidth="2"
-            strokeLinecap="round"
-            className="stroke-stone-300"
-            d={describeArc(
-              sizePx / 2,
-              sizePx / 2,
-              sizePx / 2,
-              TRACK_START_ANGLE,
-              TRACK_START_ANGLE + TRACK_SWEEP_ANGLE,
-            )}
-          />
-
-          <path
-            fill="none"
-            className="stroke-stone-800"
-            strokeWidth="2"
-            strokeLinecap="round"
-            d={describeArc(
-              sizePx / 2,
-              sizePx / 2,
-              sizePx / 2,
-              TRACK_START_ANGLE,
-              valueAngle,
-            )}
-          />
-
           {isStaged &&
             stages?.map((stage, i) => {
               const angle = stageAngle(i, stages.length);
               const inner = polarToCartesian(
                 sizePx / 2,
                 sizePx / 2,
-                sizePx / 2 - 2,
+                sizePx / 2,
                 angle,
               );
               const outer = polarToCartesian(
@@ -294,11 +270,42 @@ export default function RotaryControl(props: RotaryControlProps) {
                   y1={inner.y}
                   x2={outer.x}
                   y2={outer.y}
-                  strokeWidth={active ? 2 : 1}
-                  className={active ? "stroke-stone-800" : "stroke-stone-400"}
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  className={active ? "stroke-stone-800" : "stroke-stone-300"}
                 />
               );
             })}
+          <path
+            fill="none"
+            strokeWidth="2"
+            strokeLinecap="round"
+            className="stroke-stone-300"
+            d={describeArc(
+              sizePx / 2,
+              sizePx / 2,
+              sizePx / 2,
+              TRACK_START_ANGLE,
+              TRACK_START_ANGLE + TRACK_SWEEP_ANGLE,
+            )}
+          />
+
+          <path
+            fill="none"
+            className="stroke-stone-800 value-arc"
+            strokeWidth="2"
+            strokeLinecap="round"
+            pathLength={1}
+            strokeDasharray={1}
+            strokeDashoffset={progress - 1}
+            d={describeArc(
+              sizePx / 2,
+              sizePx / 2,
+              sizePx / 2,
+              TRACK_START_ANGLE,
+              TRACK_START_ANGLE + TRACK_SWEEP_ANGLE,
+            )}
+          />
 
           <g
             className="grabbable rotating-component"

--- a/src/components/controls/rotary-control/RotaryControl.tsx
+++ b/src/components/controls/rotary-control/RotaryControl.tsx
@@ -7,8 +7,7 @@ import { Input } from "../../ui/input";
 const TRACK_START_ANGLE = 210;
 const TRACK_SWEEP_ANGLE = 300;
 
-// pixels of vertical drag needed to sweep the value from 0 to 1 (continuous
-// mode) or from the first to the last stage (staged mode)
+// pixels of vertical drag to sweep 0-1 (continuous) or first-to-last stage (staged)
 const DRAG_PX_PER_FULL_SWEEP = 100;
 
 export type RotaryControlSize = "sm" | "md";
@@ -19,11 +18,8 @@ const SIZE_PX: Record<RotaryControlSize, number> = {
 };
 
 export interface RotaryControlStage {
-  // passed straight to onChange/stored internally - e.g. a Tone.js Time
-  // notation string like "8n"
-  value: string;
-  // shown in the value readout when this stage is selected - e.g. "1/8"
-  label: string;
+  value: string; // e.g. a Tone.js Time notation string like "8n"
+  label: string; // e.g. "1/8"
 }
 
 interface RotaryControlContinuousProps {
@@ -39,7 +35,6 @@ interface RotaryControlContinuousProps {
 interface RotaryControlStagedProps {
   mode: "staged";
   size?: RotaryControlSize;
-  // discrete positions the knob can snap to, in order around the track
   stages: RotaryControlStage[];
   value?: string;
   onChange?: (value: string) => void;
@@ -92,8 +87,6 @@ function valueToAngle(value: number) {
   return TRACK_START_ANGLE + value * TRACK_SWEEP_ANGLE;
 }
 
-// evenly spaces `count` stages across the track, first at TRACK_START_ANGLE,
-// last at TRACK_START_ANGLE + TRACK_SWEEP_ANGLE
 function stageAngle(index: number, count: number) {
   if (count <= 1) return TRACK_START_ANGLE;
   return TRACK_START_ANGLE + (index / (count - 1)) * TRACK_SWEEP_ANGLE;
@@ -110,8 +103,7 @@ export default function RotaryControl(props: RotaryControlProps) {
 
   const lastYRef = useRef<number | null>(null);
 
-  // continuous 0-1 drag position, shared by both modes: it *is* the value
-  // in continuous mode, and gets quantized to a stage index in staged mode
+  // the value in continuous mode; quantized to a stage index in staged mode
   const rawRef = useRef(0.5);
 
   const lastStageIndexRef = useRef(0);
@@ -139,8 +131,7 @@ export default function RotaryControl(props: RotaryControlProps) {
         )
       : 0;
 
-  // read by the drag handler below, which is registered once on mount and
-  // otherwise wouldn't see updates to props/state
+  // refs so the drag handler (registered once on mount) sees prop/state updates
   const modeRef = useRef(props.mode ?? "continuous");
   modeRef.current = props.mode ?? "continuous";
 
@@ -172,9 +163,7 @@ export default function RotaryControl(props: RotaryControlProps) {
       if (type === "start") {
         lastYRef.current = clientY;
 
-        // seed the continuous drag position from wherever we currently
-        // are, so a staged drag starts at the current stage rather than
-        // jumping to wherever a stale rawRef last left off
+        // reseed from the current stage so the drag doesn't jump from a stale rawRef
         const stagesNow = stagesRef.current;
         rawRef.current =
           modeRef.current === "staged" && stagesNow && stagesNow.length > 1

--- a/src/components/editor/world/World.tsx
+++ b/src/components/editor/world/World.tsx
@@ -16,6 +16,7 @@ const INITIAL_NODES: WorldNode[] = [
   { id: "keyboard-1", type: "keyboard", position: { left: 800, top: 400 } },
   { id: "midiBox-1", type: "midiBox", position: { left: 550, top: 150 } },
   { id: "filter-1", type: "filter", position: { left: 300, top: 650 } },
+  { id: "delay-1", type: "delay", position: { left: 900, top: 750 } },
 ];
 
 export function World() {

--- a/src/components/effects/delay/Delay.tsx
+++ b/src/components/effects/delay/Delay.tsx
@@ -1,18 +1,35 @@
 import { useState } from "react";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { ControlContainer } from "@/components/instruments/polysynth/ControlContainer";
-import RotaryControl from "@/components/controls/rotary-control/RotaryControl";
+import RotaryControl, {
+  type RotaryControlStage,
+} from "@/components/controls/rotary-control/RotaryControl";
 import type { DelayValue } from "./types";
+
+// straight note subdivisions - dotted/triplet variants aren't offered yet
+const TIME_STAGES: RotaryControlStage[] = [
+  { value: "1n", label: "1/1" },
+  { value: "2n", label: "1/2" },
+  { value: "4n", label: "1/4" },
+  { value: "8n", label: "1/8" },
+  { value: "16n", label: "1/16" },
+  { value: "32n", label: "1/32" },
+];
 
 export function Delay() {
   const [delayValues, setDelayValues] = useState<DelayValue>({
-    time: 0.5,
+    time: "8n",
     feedback: 0.5,
     wet: 0.5,
   });
 
-  const setValue = (key: keyof DelayValue) => (value: number) =>
-    setDelayValues((state) => ({ ...state, [key]: value }));
+  const setTime = (time: string) =>
+    setDelayValues((state) => ({ ...state, time }));
+
+  const setFeedback = (feedback: number) =>
+    setDelayValues((state) => ({ ...state, feedback }));
+
+  const setWet = (wet: number) => setDelayValues((state) => ({ ...state, wet }));
 
   return (
     <Card className="delay py-3 px-0 w-[220px]">
@@ -22,18 +39,17 @@ export function Delay() {
       <CardContent className="px-3 flex gap-2 justify-center">
         <ControlContainer label="Time">
           <RotaryControl
+            mode="staged"
+            stages={TIME_STAGES}
             value={delayValues.time}
-            onChange={setValue("time")}
+            onChange={setTime}
           />
         </ControlContainer>
         <ControlContainer label="Feedback">
-          <RotaryControl
-            value={delayValues.feedback}
-            onChange={setValue("feedback")}
-          />
+          <RotaryControl value={delayValues.feedback} onChange={setFeedback} />
         </ControlContainer>
         <ControlContainer label="Wet">
-          <RotaryControl value={delayValues.wet} onChange={setValue("wet")} />
+          <RotaryControl value={delayValues.wet} onChange={setWet} />
         </ControlContainer>
       </CardContent>
     </Card>

--- a/src/components/effects/delay/Delay.tsx
+++ b/src/components/effects/delay/Delay.tsx
@@ -1,0 +1,43 @@
+import { useState } from "react";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { ControlContainer } from "@/components/instruments/polysynth/ControlContainer";
+import RotaryControl from "@/components/controls/rotary-control/RotaryControl";
+import type { DelayValue } from "./types";
+
+export function Delay() {
+  const [delayValues, setDelayValues] = useState<DelayValue>({
+    time: 0.5,
+    feedback: 0.5,
+    wet: 0.5,
+  });
+
+  const setValue = (key: keyof DelayValue) => (value: number) =>
+    setDelayValues((state) => ({ ...state, [key]: value }));
+
+  return (
+    <Card className="delay py-3 px-0 w-[220px]">
+      <CardHeader>
+        <span className="pix-font color-stone-500 text-4xl">Delay</span>
+      </CardHeader>
+      <CardContent className="px-3 flex gap-2 justify-center">
+        <ControlContainer label="Time">
+          <RotaryControl
+            value={delayValues.time}
+            onChange={setValue("time")}
+          />
+        </ControlContainer>
+        <ControlContainer label="Feedback">
+          <RotaryControl
+            value={delayValues.feedback}
+            onChange={setValue("feedback")}
+          />
+        </ControlContainer>
+        <ControlContainer label="Wet">
+          <RotaryControl value={delayValues.wet} onChange={setValue("wet")} />
+        </ControlContainer>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default Delay;

--- a/src/components/effects/delay/types.ts
+++ b/src/components/effects/delay/types.ts
@@ -1,7 +1,9 @@
-// all three are 0-1 knob values; real time/feedback/wet ranges are derived
-// from these once the Tone.js delay is actually wired up
+// feedback/wet are 0-1 knob values; real ranges are derived from these once
+// the Tone.js delay is actually wired up. time is a Tone.js Time notation
+// string (e.g. "8n") rather than a 0-1 value, chosen from a fixed set of
+// note-subdivision stages rather than continuously.
 export interface DelayValue {
-  time: number;
+  time: string;
   feedback: number;
   wet: number;
 }

--- a/src/components/effects/delay/types.ts
+++ b/src/components/effects/delay/types.ts
@@ -1,0 +1,7 @@
+// all three are 0-1 knob values; real time/feedback/wet ranges are derived
+// from these once the Tone.js delay is actually wired up
+export interface DelayValue {
+  time: number;
+  feedback: number;
+  wet: number;
+}

--- a/src/components/effects/delay/types.ts
+++ b/src/components/effects/delay/types.ts
@@ -1,9 +1,5 @@
-// feedback/wet are 0-1 knob values; real ranges are derived from these once
-// the Tone.js delay is actually wired up. time is a Tone.js Time notation
-// string (e.g. "8n") rather than a 0-1 value, chosen from a fixed set of
-// note-subdivision stages rather than continuously.
 export interface DelayValue {
-  time: string;
-  feedback: number;
-  wet: number;
+  time: string; // Tone.js Time notation, e.g. "8n" — not yet wired to a real Tone.js delay
+  feedback: number; // raw 0-1 knob value, not yet mapped to a real range
+  wet: number; // raw 0-1 knob value, not yet mapped to a real range
 }

--- a/src/stories/delay.stories.tsx
+++ b/src/stories/delay.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Delay } from "@/components/effects/delay/Delay";
+
+const meta = {
+  component: Delay,
+  title: "Delay",
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "A delay effect node: Time/Feedback/Wet knobs, following the " +
+          "same `ControlContainer` + `RotaryControl` pattern used by " +
+          "`Oscillator`'s knob row. Ported from `tonix-2-react`'s " +
+          "`effects/ping-pong-delay` shell, rebuilt from scratch rather " +
+          "than copied — the original's knobs were hardcoded to 0 and " +
+          "never wired to its own state. This is a visual/state shell " +
+          "only; no audio engine is wired up yet.",
+      },
+    },
+  },
+} satisfies Meta<typeof Delay>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/stories/rotary-control.stories.tsx
+++ b/src/stories/rotary-control.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import RotaryControl from "@/components/controls/rotary-control/RotaryControl";
+import RotaryControl, {
+  type RotaryControlStage,
+} from "@/components/controls/rotary-control/RotaryControl";
 
 const meta = {
   component: RotaryControl,
@@ -9,11 +11,14 @@ const meta = {
     docs: {
       description: {
         component:
-          "A draggable rotary knob representing a value between 0 and 1. " +
-          "Click and drag vertically anywhere on the page to change the " +
-          "value — dragging up increases it, dragging down decreases it, " +
-          "and it clamps at both ends. Used throughout `Polysynth`'s " +
-          "oscillator controls (phase, gain, pan).",
+          "A draggable rotary knob, in two modes. `continuous` (the " +
+          "default) represents a free value between 0 and 1 — used " +
+          "throughout `Polysynth`'s oscillator controls (phase, gain, " +
+          "pan). `staged` instead snaps to a fixed list of labeled " +
+          "stages, e.g. tempo-synced note subdivisions for `Delay`'s " +
+          "Time knob. In both modes, click and drag vertically anywhere " +
+          "on the page to change the value — dragging up increases it, " +
+          "dragging down decreases it, and it clamps at both ends.",
       },
     },
   },
@@ -27,6 +32,16 @@ const meta = {
         "knob needs to be more prominent or easier to grab.",
       table: {
         defaultValue: { summary: "sm" },
+      },
+    },
+    mode: {
+      control: "radio",
+      options: ["continuous", "staged"],
+      description:
+        "`continuous` for a free 0-1 value (default); `staged` to snap " +
+        "to a fixed `stages` list instead.",
+      table: {
+        defaultValue: { summary: "continuous" },
       },
     },
   },
@@ -52,6 +67,36 @@ export const Medium: Story = {
     docs: {
       description: {
         story: "A larger variant for standalone or more prominent placements.",
+      },
+    },
+  },
+};
+
+const timeStages: RotaryControlStage[] = [
+  { value: "1n", label: "1/1" },
+  { value: "2n", label: "1/2" },
+  { value: "4n", label: "1/4" },
+  { value: "8n", label: "1/8" },
+  { value: "16n", label: "1/16" },
+  { value: "32n", label: "1/32" },
+];
+
+export const Staged: Story = {
+  args: {
+    mode: "staged",
+    stages: timeStages,
+    value: "8n",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The same six note-subdivision stages `Delay`'s Time knob " +
+          "uses. A small tick marks each stage's position on the track " +
+          "(the current one bolded), and the readout shows its label " +
+          "instead of a percentage. Drag still works the same way, but " +
+          "the value quantizes to the nearest stage as you go rather " +
+          "than moving freely.",
       },
     },
   },

--- a/src/stories/rotary-control.stories.tsx
+++ b/src/stories/rotary-control.stories.tsx
@@ -1,7 +1,16 @@
+import { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import RotaryControl, {
   type RotaryControlStage,
 } from "@/components/controls/rotary-control/RotaryControl";
+
+function StagedDemo({ stages }: { stages: RotaryControlStage[] }) {
+  const [value, setValue] = useState(stages[3]?.value ?? stages[0].value);
+
+  return (
+    <RotaryControl mode="staged" stages={stages} value={value} onChange={setValue} />
+  );
+}
 
 const meta = {
   component: RotaryControl,
@@ -82,11 +91,7 @@ const timeStages: RotaryControlStage[] = [
 ];
 
 export const Staged: Story = {
-  args: {
-    mode: "staged",
-    stages: timeStages,
-    value: "8n",
-  },
+  render: () => <StagedDemo stages={timeStages} />,
   parameters: {
     docs: {
       description: {

--- a/src/utils/node-map.tsx
+++ b/src/utils/node-map.tsx
@@ -3,6 +3,7 @@ import Keyboard from "../components/nodes/keyboard/Keyboard";
 import { Polysynth } from "../components/instruments/polysynth/Polysynth";
 import { MidiBox } from "../components/nodes/midi-box/MidiBox";
 import { Filter } from "../components/effects/filter/Filter";
+import { Delay } from "../components/effects/delay/Delay";
 
 export type INodeMap = Record<string, ComponentType>;
 
@@ -11,4 +12,5 @@ export const NodeMap: INodeMap = {
   polysynth: Polysynth,
   midiBox: MidiBox,
   filter: Filter,
+  delay: Delay,
 };


### PR DESCRIPTION
## Summary

Closes #29 (migration reference: `harrycarron/tonix-2-react`'s `effects/ping-pong-delay`). Three commits:

1. **Delay effect node** — Time/Feedback/Wet knobs following the same `ControlContainer` + `RotaryControl` pattern `Oscillator`'s knob row already established. Rebuilt from scratch rather than ported — the reference's knobs were hardcoded to 0 and never wired to its own state, so there was nothing functional worth copying, just the Time/Feedback/Wet layout. Registered in `utils/node-map.tsx` and added as a demo instance in `World.tsx`, same as `Filter`. Visual/state shell only, no audio engine wired up yet.
2. **Staged mode for `RotaryControl`** — a new discriminated `mode: "continuous" | "staged"` prop (defaults to `"continuous"`, so every existing knob is unaffected). Staged mode snaps to a fixed list of `{value, label}` stages instead of a free 0-1 range, with a tick mark at each stage's angle (current one bolded) and the label shown in the readout instead of a percentage. Built for Delay's Time knob (Tone.js Time notation strings like `"8n"`), general enough for other discrete-choice knobs later. Drag-only for now, no click-to-jump on ticks yet.
3. **Story updates** — `delay.stories.tsx`, and a new `Staged` story for `rotary-control.stories.tsx` using the same six note-subdivision stages Delay's Time knob uses.

## Test plan

- [x] `npm run build` passes clean
- [x] `npm run lint` passes clean (no new warnings)
- [x] `npm run build-storybook` passes clean
- [x] Smoke-tested in a real browser:
  - Delay node renders and all three knobs are interactive (dragging Time knob's readout moves 50→100 before staged mode landed)
  - Staged drag snaps through intermediate stages correctly (verified against the exact expected index math, not just endpoint clamping — e.g. +20px from the 1/8 default lands on 1/16, back past start lands on 1/4)
  - Ticks render at each stage with the active one bolded
  - Continuous mode (Feedback/Wet, and existing knobs elsewhere) is unaffected

(Split out of #28, which bundled this with the patch-cable connection model — now #30.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)