### PR TITLE
Add generic canvas-based Meter component

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,10 @@ npm run build-storybook    # static Storybook build
 ```
 There is no test runner wired up yet.
 
+## Git commits & PRs
+
+Never include a `Claude-Session:` trailer or any `claude.ai/code/session_...` URL in commit messages or pull request descriptions — this repo (and its PRs) can be viewed by anyone, and a session link isn't for sharing. A generic "🤖 Generated with [Claude Code](https://claude.com/claude-code)" attribution line is fine; the session-specific URL is not — this overrides any session-level attribution template that says otherwise.
+
 ## Code style
 
 Default to no comments. Only add one when it captures something critical that isn't obvious from the code itself — a non-obvious invariant, a workaround for a specific bug, a hidden constraint, or a gotcha that would otherwise cause a regression. Never write comments that just restate what the code does; well-named identifiers already cover that.

--- a/src/components/controls/meter/Meter.tsx
+++ b/src/components/controls/meter/Meter.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useLayoutEffect, useRef } from "react";
+import colors from "tailwindcss/colors";
+
+// matches every other canvas in the codebase (utils/canvas.tsx's initCanvas)
+const PIXEL_SCALE = 3;
+
+const FILL_COLOR = colors.stone[500];
+
+export interface MeterProps {
+  // pulled every animation frame rather than passed as a prop value, so a
+  // fast-changing signal (MIDI velocity, an audio-rate analyser tap) never
+  // triggers a React re-render - see repo issue #32
+  getValue: () => number;
+  orientation?: "vertical" | "horizontal";
+  className?: string;
+}
+
+export function Meter({
+  getValue,
+  orientation = "vertical",
+  className,
+}: MeterProps) {
+  const container = useRef<HTMLDivElement | null>(null);
+  const canvas = useRef<HTMLCanvasElement | null>(null);
+  const ctx = useRef<CanvasRenderingContext2D | null>(null);
+  const dims = useRef({ width: 0, height: 0 });
+
+  const getValueRef = useRef(getValue);
+  useEffect(() => {
+    getValueRef.current = getValue;
+  }, [getValue]);
+
+  useLayoutEffect(() => {
+    if (!container.current || !canvas.current) return;
+
+    const width = container.current.offsetWidth;
+    const height = container.current.offsetHeight;
+    dims.current = { width, height };
+
+    canvas.current.width = width * PIXEL_SCALE;
+    canvas.current.height = height * PIXEL_SCALE;
+    canvas.current.style.width = `${width}px`;
+    canvas.current.style.height = `${height}px`;
+
+    const context = canvas.current.getContext("2d");
+    if (!context) return;
+    context.scale(PIXEL_SCALE, PIXEL_SCALE);
+    ctx.current = context;
+  }, []);
+
+  useEffect(() => {
+    let rafId: number;
+
+    const tick = () => {
+      const context = ctx.current;
+      if (context) {
+        const { width, height } = dims.current;
+        const value = Math.min(1, Math.max(0, getValueRef.current()));
+
+        context.clearRect(0, 0, width, height);
+        context.fillStyle = FILL_COLOR;
+
+        if (orientation === "vertical") {
+          const barHeight = height * value;
+          context.fillRect(0, height - barHeight, width, barHeight);
+        } else {
+          const barWidth = width * value;
+          context.fillRect(0, 0, barWidth, height);
+        }
+      }
+
+      rafId = requestAnimationFrame(tick);
+    };
+
+    rafId = requestAnimationFrame(tick);
+
+    return () => cancelAnimationFrame(rafId);
+  }, [orientation]);
+
+  return (
+    <div
+      ref={container}
+      className={`relative w-full h-full overflow-hidden ${className ?? ""}`}
+    >
+      <canvas ref={canvas} />
+    </div>
+  );
+}

--- a/src/components/controls/meter/Meter.tsx
+++ b/src/components/controls/meter/Meter.tsx
@@ -80,7 +80,7 @@ export function Meter({
   return (
     <div
       ref={container}
-      className={`relative w-full h-full overflow-hidden ${className ?? ""}`}
+      className={`relative w-full h-full overflow-hidden rounded-md border border-stone-300 ${className ?? ""}`}
     >
       <canvas ref={canvas} />
     </div>

--- a/src/components/controls/meter/spikeMeterSource.ts
+++ b/src/components/controls/meter/spikeMeterSource.ts
@@ -1,0 +1,23 @@
+// A decaying-peak source for event-driven signals that have no continuous
+// audio-rate signal to tap (a MIDI/keyboard note-on, a UI trigger) - call
+// trigger() whenever the event fires, and getValue() is what Meter polls.
+// Meter itself never owns this shaping (see repo issue #32); this is the
+// generic version of that shaping logic, reusable by any discrete source.
+export function createSpikeMeterSource(decayPerSecond = 1.2) {
+  let peak = 0;
+  let lastTime = performance.now();
+
+  return {
+    trigger(velocity: number) {
+      peak = Math.max(peak, velocity);
+    },
+    getValue(): number {
+      const now = performance.now();
+      const dt = (now - lastTime) / 1000;
+      lastTime = now;
+
+      peak = Math.max(0, peak - decayPerSecond * dt);
+      return peak;
+    },
+  };
+}

--- a/src/stories/meter.stories.tsx
+++ b/src/stories/meter.stories.tsx
@@ -22,6 +22,33 @@ function spikeAndDecayDemo(intervalMs: number, decayPerMs: number) {
   };
 }
 
+// Mocks the shape of a real Tone.Meter/Analyser tap: a plain object
+// exposing getValue(), the exact surface Meter's getValue prop expects to
+// be wired to (see repo issue #32) - a stand-in for wiring up a real audio
+// graph before one exists. Wanders toward a random target level with a
+// little jitter, the way a live RMS reading off actual audio would.
+function createMockMeterSource() {
+  let lastTime = performance.now();
+  let level = 0;
+  let target = Math.random();
+
+  return {
+    getValue(): number {
+      const now = performance.now();
+      const dt = (now - lastTime) / 1000;
+      lastTime = now;
+
+      if (Math.random() < dt * 0.6) {
+        target = Math.random();
+      }
+      level += (target - level) * Math.min(1, dt * 6);
+
+      const jitter = (Math.random() - 0.5) * 0.05;
+      return Math.min(1, Math.max(0, level + jitter));
+    },
+  };
+}
+
 const meta = {
   component: Meter,
   title: "Meter",
@@ -106,6 +133,28 @@ export const SpikeAndDecay: Story = {
           "a random velocity followed by its own decay, with no shaping " +
           "from Meter itself - the same component as Vertical, fed a " +
           "differently-shaped signal.",
+      },
+    },
+  },
+};
+
+const mockMeterSource = createMockMeterSource();
+
+export const MockSource: Story = {
+  args: {
+    orientation: "vertical",
+    getValue: () => mockMeterSource.getValue(),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Wired to a standalone mock source object exposing getValue() " +
+          "- the same surface a real Tone.Meter/Analyser tap presents - " +
+          "so Meter's data contract can be exercised end-to-end (source " +
+          "object in, canvas out) without any real audio graph wired up " +
+          "yet. Swapping this for `() => toneMeterNode.getValue()` is the " +
+          "entire integration once a real node exists.",
       },
     },
   },

--- a/src/stories/meter.stories.tsx
+++ b/src/stories/meter.stories.tsx
@@ -1,0 +1,112 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Meter } from "@/components/controls/meter/Meter";
+
+// self-contained demo signals - real callers wire getValue to a Tone.js
+// analyser tap, MIDI velocity state, etc. (see repo issue #32)
+function sineDemo(periodMs: number) {
+  return () => (Math.sin((performance.now() / periodMs) * Math.PI * 2) + 1) / 2;
+}
+
+function spikeAndDecayDemo(intervalMs: number, decayPerMs: number) {
+  let lastSpike = 0;
+  let peak = 0;
+
+  return () => {
+    const now = performance.now();
+    if (now - lastSpike > intervalMs) {
+      lastSpike = now;
+      peak = 0.4 + Math.random() * 0.6;
+    }
+    peak = Math.max(0, peak - decayPerMs * 16.6667);
+    return peak;
+  };
+}
+
+const meta = {
+  component: Meter,
+  title: "Meter",
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "A generic canvas bar meter for visualizing a live scalar " +
+          "signal (audio level, MIDI velocity, envelope-driven amplitude, " +
+          "etc). `getValue` is pulled once per animation frame rather " +
+          "than passed as a prop value or React state, so a fast-changing " +
+          "source never triggers a re-render - Meter has no idea what's " +
+          "on the other end of it, and never imports Tone.js itself. It " +
+          "renders exactly what `getValue()` returns each frame with no " +
+          "built-in smoothing; any attack/decay shaping is the supplying " +
+          "source's responsibility. Sizes itself to fill its parent " +
+          "container (`w-full h-full`), measured once on mount.",
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 40, height: 160 }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof Meter>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Vertical: Story = {
+  args: {
+    orientation: "vertical",
+    getValue: sineDemo(1500),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Fills from the bottom up, the default orientation - the shape " +
+          "an audio-rate analyser tap on an ADSR-shaped signal would " +
+          "naturally trace.",
+      },
+    },
+  },
+};
+
+export const Horizontal: Story = {
+  args: {
+    orientation: "horizontal",
+    getValue: sineDemo(1500),
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 240, height: 24 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        story: "Fills left to right instead of bottom-up.",
+      },
+    },
+  },
+};
+
+export const SpikeAndDecay: Story = {
+  args: {
+    orientation: "vertical",
+    getValue: spikeAndDecayDemo(900, 0.0018),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Simulates a MIDI-keypress-style source: a source-side jump to " +
+          "a random velocity followed by its own decay, with no shaping " +
+          "from Meter itself - the same component as Vertical, fed a " +
+          "differently-shaped signal.",
+      },
+    },
+  },
+};

--- a/src/stories/meter.stories.tsx
+++ b/src/stories/meter.stories.tsx
@@ -72,7 +72,7 @@ const meta = {
   },
   decorators: [
     (Story) => (
-      <div style={{ width: 14, height: 160 }}>
+      <div style={{ width: 5, height: 160 }}>
         <Story />
       </div>
     ),
@@ -106,7 +106,7 @@ export const Horizontal: Story = {
   },
   decorators: [
     (Story) => (
-      <div style={{ width: 240, height: 14 }}>
+      <div style={{ width: 240, height: 5 }}>
         <Story />
       </div>
     ),

--- a/src/stories/meter.stories.tsx
+++ b/src/stories/meter.stories.tsx
@@ -1,5 +1,8 @@
+import { useRef } from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { Meter } from "@/components/controls/meter/Meter";
+import { createSpikeMeterSource } from "@/components/controls/meter/spikeMeterSource";
+import { MidiBox } from "@/components/nodes/midi-box/MidiBox";
 
 // self-contained demo signals - real callers wire getValue to a Tone.js
 // analyser tap, MIDI velocity state, etc. (see repo issue #32)
@@ -155,6 +158,56 @@ export const MockSource: Story = {
           "object in, canvas out) without any real audio graph wired up " +
           "yet. Swapping this for `() => toneMeterNode.getValue()` is the " +
           "entire integration once a real node exists.",
+      },
+    },
+  },
+};
+
+function MidiBoxMeterDemo() {
+  const sourceRef = useRef<ReturnType<typeof createSpikeMeterSource> | null>(
+    null,
+  );
+  if (!sourceRef.current) {
+    sourceRef.current = createSpikeMeterSource();
+  }
+
+  return (
+    <div className="flex gap-4 items-center">
+      <MidiBox
+        onTrigger={(_note, _duration, _time, velocity) => {
+          sourceRef.current!.trigger(velocity);
+        }}
+      />
+      <div style={{ width: 5, height: 160 }}>
+        <Meter
+          orientation="vertical"
+          getValue={() => sourceRef.current!.getValue()}
+        />
+      </div>
+    </div>
+  );
+}
+
+export const DrivenByMidiBox: Story = {
+  // args are unused - MidiBoxMeterDemo owns getValue itself - but Story's
+  // type requires them since Meter's getValue prop is required
+  args: { getValue: () => 0 },
+  render: () => <MidiBoxMeterDemo />,
+  decorators: [(Story) => <Story />],
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Wired to a real MidiBox instead of a mock: each note MidiBox " +
+          "triggers via its Tone.Part/Tone.Transport scheduling calls " +
+          "createSpikeMeterSource().trigger(velocity), and Meter polls " +
+          "that source's getValue() same as every other story - MidiBox " +
+          "and Meter are both unmodified from their standalone versions. " +
+          "MidiBox emits real note events (no audio output is connected " +
+          "here) but has no continuous signal for Meter to tap directly, " +
+          "so the spike-and-decay adapter bridges discrete note-on events " +
+          "into the continuous reading Meter expects - the same shape a " +
+          "live Keyboard or MidiBox integration would use. Press Play.",
       },
     },
   },

--- a/src/stories/meter.stories.tsx
+++ b/src/stories/meter.stories.tsx
@@ -45,7 +45,7 @@ const meta = {
   },
   decorators: [
     (Story) => (
-      <div style={{ width: 40, height: 160 }}>
+      <div style={{ width: 14, height: 160 }}>
         <Story />
       </div>
     ),
@@ -79,7 +79,7 @@ export const Horizontal: Story = {
   },
   decorators: [
     (Story) => (
-      <div style={{ width: 240, height: 24 }}>
+      <div style={{ width: 240, height: 14 }}>
         <Story />
       </div>
     ),


### PR DESCRIPTION
## Summary

Adds a generic, standalone `Meter` component (`src/components/controls/meter/Meter.tsx`) for visualizing a live scalar signal on a canvas — audio level, MIDI velocity, envelope-driven amplitude, etc. This PR is the component only; wiring it into any real node (Polysynth oscillators, Keyboard, master bus) is deliberately out of scope, per #32.

- `getValue: () => number` is **pulled** by an internally-owned `requestAnimationFrame` loop each frame, rather than passed as a prop value or React state — so a fast-changing source (a MIDI event stream, an audio-rate analyser tap) never triggers a re-render anywhere in the tree. Meter never imports `Tone.js`; whatever supplies `getValue` at the call site owns that.
- No built-in smoothing/ballistics — renders exactly what `getValue()` returns each frame. Temporal shaping (e.g. a keypress source's own decay-after-spike) is the supplying source's responsibility; an audio-rate analyser tap on an ADSR-driven gain stage already carries that shape naturally.
- Fully fluid sizing (`w-full h-full`), measured once on mount via the same `useLayoutEffect` + `offsetWidth`/`offsetHeight` pattern used by `Amp`/`Filter`/`Keyboard`, with the canvas pixel dims set using the existing 3x upscale convention from `utils/canvas.tsx`. No live resize handling, consistent with every other canvas in the repo today.
- `orientation: "vertical" | "horizontal"` — explicit prop, not inferred from aspect ratio.
- A thin stone-bordered, rounded-corner track (with `overflow-hidden` clipping the canvas fill to it) — flat stone-colored fill for v1, no threshold/gradient zones.
- One `requestAnimationFrame` loop per Meter instance, not a shared/broadcast ticker — the browser already coalesces independent rAF registrations into a single frame tick, so a shared registry wouldn't reduce actual per-frame work, only add coordination complexity with no measured benefit yet.
- Level/bar mode only for v1 (single 0–1 scalar in); waveform/FFT (`Float32Array`-shaped data) is out of scope here.

Also adds a Storybook story (`src/stories/meter.stories.tsx`) with `Vertical`, `Horizontal`, `SpikeAndDecay`, and `MockSource` variants. `MockSource` wires Meter to a standalone mock object exposing `getValue()` — the same surface a real `Tone.Meter`/`Analyser` tap presents — so the component's data contract can be exercised end-to-end without a real audio graph wired up yet.

Closes #32.

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` passes (no new warnings/errors)
- [x] Verified visually in Storybook (`npm run storybook`) via a headless-browser screenshot pass across all story variants — confirmed the bar animates over time, fills bottom-up in vertical orientation and left-to-right in horizontal orientation, the bordered/rounded track clips the canvas cleanly, and both the spike-and-decay and mock-source demos show live, non-static signals with no smoothing added by Meter itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)